### PR TITLE
Add return type

### DIFF
--- a/classes/GdLib.php
+++ b/classes/GdLib.php
@@ -7,7 +7,7 @@ use claviska\SimpleImage;
 
 class GdLib extends Darkroom\GdLib
 {
-    protected function resize(SimpleImage $image, array $options)
+    protected function resize(SimpleImage $image, array $options): SimpleImage
     {
         // clip
         if (isset($options['clip'])) {


### PR DESCRIPTION
I have added the return type `SimpleImage` to the resize function in the GdLib class. This should fix #27 and make the plugin work in Kirby 3.8. I have tested it in one of my Kirby installs, but please also test this yourself. 😅